### PR TITLE
Fix olm subscriptions

### DIFF
--- a/modules/olm-subscriptions/chart/templates/flink.yaml
+++ b/modules/olm-subscriptions/chart/templates/flink.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if and .Values.components.flink }}
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Values.flink.name }}
+  namespace: {{ .Values.install_namespace }}
+spec:
+  channel: {{ .Values.flink.channel }}
+  installPlanApproval: {{ .Values.flink.approval }}  
+  source: {{ .Values.flink.source }}
+  sourceNamespace: {{ .Values.catalog_namespace }}
+  name: {{ .Values.flink.name }}
+{{- end }}

--- a/modules/olm-subscriptions/chart/templates/flinksql.yaml
+++ b/modules/olm-subscriptions/chart/templates/flinksql.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if and .Values.components.flinkSql }}
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Values.flinkSql.name }}
+  namespace: {{ .Values.install_namespace }}
+spec:
+  channel: {{ .Values.flinkSql.channel }}
+  installPlanApproval: {{ .Values.flinkSql.approval }}  
+  source: {{ .Values.flinkSql.source }}
+  sourceNamespace: {{ .Values.catalog_namespace }}
+  name: {{ .Values.flinkSql.name }}
+{{- end }}

--- a/modules/olm-subscriptions/chart/templates/functionmesh.yaml
+++ b/modules/olm-subscriptions/chart/templates/functionmesh.yaml
@@ -28,9 +28,9 @@ spec:
   config:
     env:
     - name: ENABLE_WEBHOOKS
-      value: {{ .Values.functionMesh.config.enableWebhooks }}
+      value: "{{ .Values.functionMesh.config.enableWebhooks }}"
     - name: ENABLE_FUNCTION_MESH_CONTROLLER
-      value: {{ .Values.functionMesh.config.enableController }}
+      value: "{{ .Values.functionMesh.config.enableController }}"
   installPlanApproval: {{ .Values.functionMesh.approval }}  
   source: {{ .Values.functionMesh.source }}
   sourceNamespace: {{ .Values.catalog_namespace }}

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -28,6 +28,8 @@ components:
   functionMesh: true
   prometheus: true
   pulsar: true
+  flink: true
+  flinkSql: true
   zookeeper: true
 
 bookkeeper:
@@ -35,6 +37,18 @@ bookkeeper:
   channel: stable
   source: sn-catalog
   name: bookkeeper-operator
+
+flink:
+  approval: Automatic
+  channel: stable
+  source: sn-catalog
+  name: flink-on-k8s-operator
+
+flinkSql:
+  approval: Automatic
+  channel: stable
+  source: sn-catalog
+  name: sql-operator
 
 functionMesh:
   approval: Automatic

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -25,7 +25,7 @@ sn_image: ""
 
 components:
   bookkeeper: true
-  function-mesh: true
+  functionMesh: true
   prometheus: true
   pulsar: true
   zookeeper: true


### PR DESCRIPTION
- `components.functionMesh` should be used as the switch
- Only string values are allowed in `spec.config.env.value`
- Add OLM subscriptions to the Flink operator and Flink SQL operator