### PR TITLE
Fixed/update lifecyle manager var type

### DIFF
--- a/modules/operator-lifecycle-manager/main.tf
+++ b/modules/operator-lifecycle-manager/main.tf
@@ -51,7 +51,7 @@ locals {
 }
 
 resource "kubernetes_namespace" "olm_install" {
-  count = var.create_install_namespace ? 1 : 0
+  count = local.create_install_namespace ? 1 : 0
   metadata {
     name = local.install_namespace
   }

--- a/modules/operator-lifecycle-manager/variables.tf
+++ b/modules/operator-lifecycle-manager/variables.tf
@@ -55,7 +55,7 @@ variable "cleanup_on_fail" {
 }
 
 variable "create_install_namespace" {
-  default     = null
+  default     = true
   description = "Create a namespace for the deployment."
   type        = bool
 }

--- a/modules/operator-lifecycle-manager/variables.tf
+++ b/modules/operator-lifecycle-manager/variables.tf
@@ -55,7 +55,7 @@ variable "cleanup_on_fail" {
 }
 
 variable "create_install_namespace" {
-  default     = true
+  default     =  null
   description = "Create a namespace for the deployment."
   type        = bool
 }


### PR DESCRIPTION
Because of [this issue](https://github.com/streamnative/terraform-helm-charts#why-are-all-the-variable-defaults-null) documented in our readme, we make all all the default values for variables `null` and set the actual default in a `locals{}` block in the module.

This PR fixes an issue where `count` on a resource was referencing the variable instead of the local.