### PR TITLE
Refine the OLM subscriptions Chart

### DIFF
--- a/modules/olm-subscriptions/chart/templates/bookkeeper.yaml
+++ b/modules/olm-subscriptions/chart/templates/bookkeeper.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ .Values.bookkeeper.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.bookkeeper.channel }}
-  installPlanApproval: {{ .Values.bookkeeper.approval }}  
+  channel: {{ .Values.bookkeeper.channel | default .Values.channel }}
+  installPlanApproval: {{ .Values.bookkeeper.approval | default .Values.approval }}
   source: {{ .Values.bookkeeper.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.bookkeeper.name }}

--- a/modules/olm-subscriptions/chart/templates/catalogsource.yaml
+++ b/modules/olm-subscriptions/chart/templates/catalogsource.yaml
@@ -30,33 +30,3 @@ spec:
   updateStrategy:
     registryPoll:
       interval: 10m0s
-  secrets:
-  - {{ .Values.sn_registry_secret }}
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: sn-function-mesh-catalog
-  namespace: {{ .Values.olm_namespace }}
-spec:
-  displayName: StreamNative Function Mesh Catalog
-  image: streamnative/function-mesh-catalog:latest
-  publisher: StreamNative.io
-  sourceType: grpc
-  updateStrategy:
-    registryPoll:
-      interval: 10m0s
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: sn-operator-catalog
-  namespace: {{ .Values.olm_namespace }}
-spec:
-  displayName: SN Operator Catalog
-  image: {{ .Values.sn_operator_registry }}
-  publisher: StreamNative.io
-  sourceType: grpc
-  updateStrategy:
-    registryPoll:
-      interval: 10m0s

--- a/modules/olm-subscriptions/chart/templates/flink.yaml
+++ b/modules/olm-subscriptions/chart/templates/flink.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ .Values.flink.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.flink.channel }}
-  installPlanApproval: {{ .Values.flink.approval }}  
+  channel: {{ .Values.flink.channel | default .Values.channel }}
+  installPlanApproval: {{ .Values.flink.approval | default .Values.approval }}  
   source: {{ .Values.flink.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.flink.name }}

--- a/modules/olm-subscriptions/chart/templates/flinksql.yaml
+++ b/modules/olm-subscriptions/chart/templates/flinksql.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ .Values.flinkSql.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.flinkSql.channel }}
-  installPlanApproval: {{ .Values.flinkSql.approval }}  
+  channel: {{ .Values.flinkSql.channel | default .Values.channel }}
+  installPlanApproval: {{ .Values.flinkSql.approval | default .Values.approval }}  
   source: {{ .Values.flinkSql.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.flinkSql.name }}

--- a/modules/olm-subscriptions/chart/templates/functionmesh.yaml
+++ b/modules/olm-subscriptions/chart/templates/functionmesh.yaml
@@ -24,14 +24,14 @@ metadata:
   name: {{ .Values.functionMesh.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.functionMesh.channel }}
+  channel: {{ .Values.functionMesh.channel | default .Values.channel }}
   config:
     env:
     - name: ENABLE_WEBHOOKS
       value: "{{ .Values.functionMesh.config.enableWebhooks }}"
     - name: ENABLE_FUNCTION_MESH_CONTROLLER
       value: "{{ .Values.functionMesh.config.enableController }}"
-  installPlanApproval: {{ .Values.functionMesh.approval }}  
+  installPlanApproval: {{ .Values.functionMesh.approval | default .Values.approval }}  
   source: {{ .Values.functionMesh.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.functionMesh.name }}

--- a/modules/olm-subscriptions/chart/templates/prometheus.yaml
+++ b/modules/olm-subscriptions/chart/templates/prometheus.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: {{ .Values.install_namespace }} 
 spec:
   channel: {{ .Values.prometheus.channel }}
-  installPlanApproval: {{ .Values.prometheus.approval }}  
+  installPlanApproval: {{ .Values.prometheus.approval | default .Values.approval }}  
   source: {{ .Values.prometheus.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.prometheus.name }}

--- a/modules/olm-subscriptions/chart/templates/pulsar.yaml
+++ b/modules/olm-subscriptions/chart/templates/pulsar.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ .Values.pulsar.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.pulsar.channel }}
-  installPlanApproval: {{ .Values.pulsar.approval }}  
+  channel: {{ .Values.pulsar.channel | default .Values.channel }}
+  installPlanApproval: {{ .Values.pulsar.approval | default .Values.approval }}  
   source: {{ .Values.pulsar.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.pulsar.name }}

--- a/modules/olm-subscriptions/chart/templates/sn-operator.yaml
+++ b/modules/olm-subscriptions/chart/templates/sn-operator.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ .Values.sn_operator.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.sn_operator.channel }}
-  installPlanApproval: {{ .Values.sn_operator.approval }}
+  channel: {{ .Values.sn_operator.channel | default .Values.channel }}
+  installPlanApproval: {{ .Values.sn_operator.approval | default .Values.approval }}
   source: {{ .Values.sn_operator.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.sn_operator.name }}

--- a/modules/olm-subscriptions/chart/templates/zookeeper.yaml
+++ b/modules/olm-subscriptions/chart/templates/zookeeper.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ .Values.zookeeper.name }}
   namespace: {{ .Values.install_namespace }}
 spec:
-  channel: {{ .Values.zookeeper.channel }}
-  installPlanApproval: {{ .Values.zookeeper.approval }}  
+  channel: {{ .Values.zookeeper.channel | default .Values.channel }}
+  installPlanApproval: {{ .Values.zookeeper.approval | default .Values.approval }}  
   source: {{ .Values.zookeeper.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.zookeeper.name }}

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -21,9 +21,9 @@ olm_namespace: olm
 install_namespace: sn-system
 operator_group: sn-operators
 
-sn_registry: ""
-sn_operator_registry: ""
-sn_registry_secret: "cloudsmith"
+sn_registry: "docker.cloudsmith.io/streamnative/operators/sn-catalog:latest"
+channel: stable
+approval: Automatic
 
 components:
   bookkeeper: true
@@ -36,52 +36,37 @@ components:
   sn_operator: false
 
 bookkeeper:
-  approval: Automatic
-  channel: stable
   source: sn-catalog
   name: bookkeeper-operator
 
 flink:
-  approval: Automatic
-  channel: stable
   source: sn-catalog
-  name: flink-on-k8s-operator
+  name: flink-operator
 
 flinkSql:
-  approval: Automatic
-  channel: stable
   source: sn-catalog
   name: sql-operator
 
 functionMesh:
-  approval: Automatic
-  channel: alpha
   config:
     enableWebhooks: true
     enableController: false
-  source: sn-function-mesh-catalog
+  source: sn-catalog
   name: function-mesh
 
 prometheus:
-  approval: Automatic
   channel: beta
   source: operatorhubio-catalog
   name: prometheus
 
 pulsar:
-  approval: Automatic
-  channel: stable
   source: sn-catalog
   name: pulsar-operator
 
 zookeeper:
-  approval: Automatic
-  channel: stable
   source: sn-catalog
   name: zookeeper-operator
 
 sn_operator:
-  approval: Automatic
-  channel: alpha
-  source: sn-operator-catalog
+  source: sn-catalog
   name: sn-operator

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -33,7 +33,7 @@ components:
   flink: true
   flinkSql: true
   zookeeper: true
-  sn_operator: false
+  sn_operator: true
 
 bookkeeper:
   source: sn-catalog

--- a/modules/olm-subscriptions/main.tf
+++ b/modules/olm-subscriptions/main.tf
@@ -37,7 +37,6 @@ locals {
   olm_namespace     = var.olm_namespace != null ? var.olm_namespace : "olm"
   release_name      = var.release_name != null ? var.release_name : "olm-subscriptions"
   channel           = var.channel != null ? var.channel : "stable"
-  registry          = var.registry != null ? var.registry : "docker.cloudsmith.io/streamnative/operators/registry/pulsar-operators:master"
   settings          = var.settings != null ? var.settings : {}
   timeout           = var.timeout != null ? var.timeout : 120
   values            = var.values != null ? var.values : []
@@ -64,12 +63,6 @@ resource "helm_release" "olm_subscriptions" {
   set {
     name  = "install_namespace"
     value = local.install_namespace
-    type  = "string"
-  }
-
-  set {
-    name  = "sn_registry"
-    value = local.registry
     type  = "string"
   }
 

--- a/modules/olm-subscriptions/main.tf
+++ b/modules/olm-subscriptions/main.tf
@@ -36,6 +36,7 @@ locals {
   install_namespace = var.install_namespace != null ? var.install_namespace : "sn-system"
   olm_namespace     = var.olm_namespace != null ? var.olm_namespace : "olm"
   release_name      = var.release_name != null ? var.release_name : "olm-subscriptions"
+  channel           = var.channel != null ? var.channel : "stable"
   registry          = var.registry != null ? var.registry : "docker.cloudsmith.io/streamnative/operators/registry/pulsar-operators:master"
   settings          = var.settings != null ? var.settings : {}
   timeout           = var.timeout != null ? var.timeout : 120
@@ -73,14 +74,8 @@ resource "helm_release" "olm_subscriptions" {
   }
 
   set {
-    name  = "sn_operator_registry"
-    value = var.sn_operator_registry
-    type  = "string"
-  }
-
-  set {
-    name  = "components.sn_operator"
-    value = var.enable_sn_operator
+    name  = "channel"
+    value = local.channel
     type  = "string"
   }
 

--- a/modules/olm-subscriptions/variables.tf
+++ b/modules/olm-subscriptions/variables.tf
@@ -70,6 +70,12 @@ variable "registry" {
   type        = string
 }
 
+variable "channel" {
+  default     = null
+  description = "The channel to subscribe to. This is required."
+  type        = string
+}
+
 variable "release_name" {
   default     = null
   description = "The name of the helm release."
@@ -80,18 +86,6 @@ variable "timeout" {
   default     = null
   description = "Time in seconds to wait for any individual kubernetes operation."
   type        = number
-}
-
-variable "enable_sn_operator" {
-  default     = false
-  description = "Whether to enable en operator."
-  type        = bool
-}
-
-variable "sn_operator_registry" {
-  default     = ""
-  description = "SN Operator's registry."
-  type        = string
 }
 
 variable "values" {


### PR DESCRIPTION
- set default `sn_registry` to `docker.cloudsmith.io/streamnative/operators/sn-catalog:latest`
- add the configuration `channel` which configures the `channel` for all subscriptions to SN operators
- add the configuration `approval` which configures the `installPlanApproval` for all subscriptions to SN operators
- let all SN operators subscribe to the same catalog source` `sn-catalog`
- remove unused catalog sources `function-mesh` and `sn-operator`