### PR TITLE
Exclude webhook port of prometheus operator from istio

### DIFF
--- a/modules/prometheus-operator/main.tf
+++ b/modules/prometheus-operator/main.tf
@@ -54,6 +54,12 @@ resource "helm_release" "prometheus_operator" {
   version          = local.chart_version
   values           = local.values
 
+  set {
+    name = "prometheusOperator.podAnnotations.traffic\\.sidecar\\.istio\\.io/excludeInboundPorts"
+    value = "10250"
+    type  = "string"
+  }
+
   dynamic "set" {
     for_each = local.settings
     content {


### PR DESCRIPTION
Part of https://github.com/streamnative/data-plane-epics/issues/4

Add annotation to exclude the webhook port from istio.