### PR TITLE
Istio authorization policies for OLM operators

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,13 +93,13 @@ module "olm_subscriptions" {
   count  = var.enable_olm ? 1 : 0
   source = "./modules/olm-subscriptions"
 
-  olm_namespace        = var.olm_namespace
-  install_namespace    = var.olm_install_namespace
-  enable_istio         = var.olm_use_istio
-  istio_root_namespace = var.olm_istio_root_namespace
-  settings             = var.olm_subscription_settings
-  registry             = var.olm_registry
-  values               = var.olm_subscription_values
+  olm_namespace          = var.olm_namespace
+  install_namespace      = var.olm_install_namespace
+  enable_istio           = var.olm_enable_istio
+  istio_system_namespace = var.olm_istio_system_namespace
+  settings               = var.olm_subscription_settings
+  registry               = var.olm_registry
+  values                 = var.olm_subscription_values
 
   depends_on = [
     module.olm

--- a/main.tf
+++ b/main.tf
@@ -93,11 +93,13 @@ module "olm_subscriptions" {
   count  = var.enable_olm ? 1 : 0
   source = "./modules/olm-subscriptions"
 
-  olm_namespace     = var.olm_namespace
-  install_namespace = var.olm_install_namespace
-  settings          = var.olm_subscription_settings
-  registry          = var.olm_registry
-  values            = var.olm_subscription_values
+  olm_namespace        = var.olm_namespace
+  install_namespace    = var.olm_install_namespace
+  enable_istio         = var.olm_use_istio
+  istio_root_namespace = var.olm_istio_root_namespace
+  settings             = var.olm_subscription_settings
+  registry             = var.olm_registry
+  values               = var.olm_subscription_values
 
   depends_on = [
     module.olm

--- a/modules/olm-subscriptions/chart/Chart.yaml
+++ b/modules/olm-subscriptions/chart/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "0.7.2"
 description: OLM Subscriptions for the StreamNative Platform
 name: olm-subscriptions
-version: 0.3.1
+version: 0.3.2
 home: https://streamnative.io
 sources:
 - https://github.com/streamnative/terraform-helm-charts

--- a/modules/olm-subscriptions/chart/Chart.yaml
+++ b/modules/olm-subscriptions/chart/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "0.7.2"
 description: OLM Subscriptions for the StreamNative Platform
 name: olm-subscriptions
-version: 0.3.2
+version: 0.4.0
 home: https://streamnative.io
 sources:
 - https://github.com/streamnative/terraform-helm-charts

--- a/modules/olm-subscriptions/chart/templates/bookkeeper.yaml
+++ b/modules/olm-subscriptions/chart/templates/bookkeeper.yaml
@@ -29,4 +29,25 @@ spec:
   source: {{ .Values.bookkeeper.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.bookkeeper.name }}
+
+---
+{{- if and .Values.istio.enabled }}
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.bookkeeper.name }}
+  namespace: {{ .Values.istio.rootNamespace }}
+spec:
+  selector:
+    matchLabels:
+      # well-known labels
+      cloud.streamnative.io/app: pulsar
+      cloud.streamnative.io/component: bookkeeper
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/{{ .Values.install_namespace }}/sa/bookkeeper-operator-controller-manager"]
+{{- end }}
+
 {{- end }}

--- a/modules/olm-subscriptions/chart/templates/pulsar.yaml
+++ b/modules/olm-subscriptions/chart/templates/pulsar.yaml
@@ -29,4 +29,25 @@ spec:
   source: {{ .Values.pulsar.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.pulsar.name }}
+
+---
+{{- if and .Values.istio.enabled }}
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.pulsar.name }}
+  namespace: {{ .Values.istio.rootNamespace }}
+spec:
+  selector:
+    matchLabels:
+      # well-known labels
+      cloud.streamnative.io/app: pulsar
+      cloud.streamnative.io/component: broker
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/{{ .Values.install_namespace }}/sa/pulsar-operator-controller-manager"]
+{{- end }}
+
 {{- end }}

--- a/modules/olm-subscriptions/chart/templates/zookeeper.yaml
+++ b/modules/olm-subscriptions/chart/templates/zookeeper.yaml
@@ -29,4 +29,25 @@ spec:
   source: {{ .Values.zookeeper.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.zookeeper.name }}
+
+---
+{{- if and .Values.istio.enabled }}
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.zookeeper.name }}
+  namespace: {{ .Values.istio.rootNamespace }}
+spec:
+  selector:
+    matchLabels:
+      # well-known labels
+      cloud.streamnative.io/app: pulsar
+      cloud.streamnative.io/component: zookeeper
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/{{ .Values.install_namespace }}/sa/zookeeper-operator-controller-manager"]
+{{- end }}
+
 {{- end }}

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -25,6 +25,10 @@ sn_registry: "docker.cloudsmith.io/streamnative/operators/sn-catalog:latest"
 channel: stable
 approval: Automatic
 
+istio:
+  enabled: false
+  rootNamespace: istio-system
+
 components:
   bookkeeper: true
   functionMesh: true

--- a/modules/olm-subscriptions/main.tf
+++ b/modules/olm-subscriptions/main.tf
@@ -28,20 +28,21 @@ terraform {
   }
 }
 locals {
-  atomic            = var.atomic != null ? var.atomic : true
-  chart_name        = var.chart_name != null ? var.chart_name : "${path.module}/chart"
-  chart_repository  = var.chart_repository != null ? var.chart_repository : null
-  chart_version     = var.chart_version != null ? var.chart_version : null
-  cleanup_on_fail   = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
-  install_namespace = var.install_namespace != null ? var.install_namespace : "sn-system"
-  olm_namespace     = var.olm_namespace != null ? var.olm_namespace : "olm"
-  release_name      = var.release_name != null ? var.release_name : "olm-subscriptions"
-  channel           = var.channel != null ? var.channel : "stable"
-  settings          = var.settings != null ? var.settings : {}
-  timeout           = var.timeout != null ? var.timeout : 120
-  values            = var.values != null ? var.values : []
+  atomic               = var.atomic != null ? var.atomic : true
+  chart_name           = var.chart_name != null ? var.chart_name : "${path.module}/chart"
+  chart_repository     = var.chart_repository != null ? var.chart_repository : null
+  chart_version        = var.chart_version != null ? var.chart_version : null
+  cleanup_on_fail      = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
+  install_namespace    = var.install_namespace != null ? var.install_namespace : "sn-system"
+  olm_namespace        = var.olm_namespace != null ? var.olm_namespace : "olm"
+  release_name         = var.release_name != null ? var.release_name : "olm-subscriptions"
+  enable_istio         = var.enable_istio != null ? var.enable_istio : false
+  istio_root_namespace = var.istio_root_namespace != null ? var.istio_root_namespace : "istio-system"
+  channel              = var.channel != null ? var.channel : "stable"
+  settings             = var.settings != null ? var.settings : {}
+  timeout              = var.timeout != null ? var.timeout : 120
+  values               = var.values != null ? var.values : []
 }
-
 
 resource "helm_release" "olm_subscriptions" {
   atomic          = local.atomic
@@ -69,6 +70,18 @@ resource "helm_release" "olm_subscriptions" {
   set {
     name  = "channel"
     value = local.channel
+    type  = "string"
+  }
+
+  set {
+    name  = "istio.enabled"
+    value = local.enable_istio
+    type  = "auto"
+  }
+
+  set {
+    name  = "istio.rootNamespace"
+    value = local.istio_root_namespace
     type  = "string"
   }
 

--- a/modules/olm-subscriptions/main.tf
+++ b/modules/olm-subscriptions/main.tf
@@ -28,20 +28,20 @@ terraform {
   }
 }
 locals {
-  atomic               = var.atomic != null ? var.atomic : true
-  chart_name           = var.chart_name != null ? var.chart_name : "${path.module}/chart"
-  chart_repository     = var.chart_repository != null ? var.chart_repository : null
-  chart_version        = var.chart_version != null ? var.chart_version : null
-  cleanup_on_fail      = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
-  install_namespace    = var.install_namespace != null ? var.install_namespace : "sn-system"
-  olm_namespace        = var.olm_namespace != null ? var.olm_namespace : "olm"
-  release_name         = var.release_name != null ? var.release_name : "olm-subscriptions"
-  enable_istio         = var.enable_istio != null ? var.enable_istio : false
-  istio_root_namespace = var.istio_root_namespace != null ? var.istio_root_namespace : "istio-system"
-  channel              = var.channel != null ? var.channel : "stable"
-  settings             = var.settings != null ? var.settings : {}
-  timeout              = var.timeout != null ? var.timeout : 120
-  values               = var.values != null ? var.values : []
+  atomic                 = var.atomic != null ? var.atomic : true
+  chart_name             = var.chart_name != null ? var.chart_name : "${path.module}/chart"
+  chart_repository       = var.chart_repository != null ? var.chart_repository : null
+  chart_version          = var.chart_version != null ? var.chart_version : null
+  cleanup_on_fail        = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
+  install_namespace      = var.install_namespace != null ? var.install_namespace : "sn-system"
+  olm_namespace          = var.olm_namespace != null ? var.olm_namespace : "olm"
+  release_name           = var.release_name != null ? var.release_name : "olm-subscriptions"
+  enable_istio           = var.enable_istio != null ? var.enable_istio : false
+  istio_system_namespace = var.istio_system_namespace != null ? var.istio_system_namespace : "istio-system"
+  channel                = var.channel != null ? var.channel : "stable"
+  settings               = var.settings != null ? var.settings : {}
+  timeout                = var.timeout != null ? var.timeout : 120
+  values                 = var.values != null ? var.values : []
 }
 
 resource "helm_release" "olm_subscriptions" {
@@ -81,7 +81,7 @@ resource "helm_release" "olm_subscriptions" {
 
   set {
     name  = "istio.rootNamespace"
-    value = local.istio_root_namespace
+    value = local.istio_system_namespace
     type  = "string"
   }
 

--- a/modules/olm-subscriptions/variables.tf
+++ b/modules/olm-subscriptions/variables.tf
@@ -82,9 +82,9 @@ variable "enable_istio" {
   type        = bool
 }
 
-variable "istio_root_namespace" {
+variable "istio_system_namespace" {
   default     = null
-  description = "The namespace to install Istio authorization policies into."
+  description = "The namespace for Istio authorization policies. Set to the Istio root namespace for cluster-wide policies."
   type        = string
 }
 

--- a/modules/olm-subscriptions/variables.tf
+++ b/modules/olm-subscriptions/variables.tf
@@ -76,6 +76,18 @@ variable "channel" {
   type        = string
 }
 
+variable "enable_istio" {
+  default     = null
+  description = "Enable Istio support. Assumes that the Istio CRDs are available."
+  type        = bool
+}
+
+variable "istio_root_namespace" {
+  default     = null
+  description = "The namespace to install Istio authorization policies into."
+  type        = string
+}
+
 variable "release_name" {
   default     = null
   description = "The name of the helm release."

--- a/variables.tf
+++ b/variables.tf
@@ -165,6 +165,18 @@ variable "olm_namespace" {
   type        = string
 }
 
+variable "olm_use_istio" {
+  default     = false
+  description = "Apply Istio authorization policies for OLM operators. Defaults to \"false\"."
+  type        = bool
+}
+
+variable "olm_istio_root_namespace" {
+  default     = "istio-system"
+  description = "The Istio root namespace for applying mesh-wide authorization policies."
+  type        = string
+}
+
 ### Otel
 variable "create_otel_collector_namespace" {
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -165,15 +165,15 @@ variable "olm_namespace" {
   type        = string
 }
 
-variable "olm_use_istio" {
+variable "olm_enable_istio" {
   default     = false
   description = "Apply Istio authorization policies for OLM operators. Defaults to \"false\"."
   type        = bool
 }
 
-variable "olm_istio_root_namespace" {
+variable "olm_istio_system_namespace" {
   default     = "istio-system"
-  description = "The Istio root namespace for applying mesh-wide authorization policies."
+  description = "The namespace for Istio authorization policies. Set to the Istio root namespace for cluster-wide policies."
   type        = string
 }
 


### PR DESCRIPTION
Related: https://github.com/streamnative/cloud-api-server/issues/1006

Note that I didn’t add policies for the various “job” pods, just the server pods that the operator might connect to.  The Flink/sql operator to be updated in a follow-up.