### PR TITLE
Updated OLM CRDs and catalog-operator template

### DIFF
--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-catalogsources.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-catalogsources.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: catalogsources.operators.coreos.com
 spec:
@@ -145,7 +145,7 @@ spec:
                   description: Represents the state of a CatalogSource. Note that Message and Reason represent the original status information, which may be migrated to be conditions based in the future. Any new features introduced will use conditions.
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - lastTransitionTime

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: clusterserviceversions.operators.coreos.com
 spec:
@@ -570,7 +570,7 @@ spec:
                                       items:
                                         type: string
                                     verbs:
-                                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
+                                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
                                       type: array
                                       items:
                                         type: string
@@ -1297,7 +1297,7 @@ spec:
                                                       type: object
                                                       properties:
                                                         exec:
-                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          description: Exec specifies the action to take.
                                                           type: object
                                                           properties:
                                                             command:
@@ -1343,7 +1343,7 @@ spec:
                                                               description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                               type: string
                                                         tcpSocket:
-                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                                           type: object
                                                           required:
                                                             - port
@@ -1358,11 +1358,11 @@ spec:
                                                                 - type: string
                                                               x-kubernetes-int-or-string: true
                                                     preStop:
-                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                                       type: object
                                                       properties:
                                                         exec:
-                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          description: Exec specifies the action to take.
                                                           type: object
                                                           properties:
                                                             command:
@@ -1408,7 +1408,7 @@ spec:
                                                               description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                               type: string
                                                         tcpSocket:
-                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                                           type: object
                                                           required:
                                                             - port
@@ -1427,7 +1427,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -1439,6 +1439,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -1489,7 +1502,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -1550,7 +1563,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -1562,6 +1575,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -1612,7 +1638,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -1661,10 +1687,10 @@ spec:
                                                   type: object
                                                   properties:
                                                     allowPrivilegeEscalation:
-                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
                                                       type: boolean
                                                     capabilities:
-                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       properties:
                                                         add:
@@ -1680,27 +1706,27 @@ spec:
                                                             description: Capability represent POSIX capabilities type
                                                             type: string
                                                     privileged:
-                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
                                                       type: boolean
                                                     procMount:
-                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
                                                       type: string
                                                     readOnlyRootFilesystem:
-                                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                                      description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                                       type: boolean
                                                     runAsGroup:
-                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: integer
                                                       format: int64
                                                     runAsNonRoot:
                                                       description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                                       type: boolean
                                                     runAsUser:
-                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: integer
                                                       format: int64
                                                     seLinuxOptions:
-                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       properties:
                                                         level:
@@ -1716,7 +1742,7 @@ spec:
                                                           description: User is a SELinux user label that applies to the container.
                                                           type: string
                                                     seccompProfile:
-                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       required:
                                                         - type
@@ -1728,7 +1754,7 @@ spec:
                                                           description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
                                                           type: string
                                                     windowsOptions:
-                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
                                                       type: object
                                                       properties:
                                                         gmsaCredentialSpec:
@@ -1748,7 +1774,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -1760,6 +1786,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -1810,7 +1849,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -1927,10 +1966,10 @@ spec:
                                             description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                                             type: boolean
                                           ephemeralContainers:
-                                            description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+                                            description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.
                                             type: array
                                             items:
-                                              description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+                                              description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                                               type: object
                                               required:
                                                 - name
@@ -2070,7 +2109,7 @@ spec:
                                                       type: object
                                                       properties:
                                                         exec:
-                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          description: Exec specifies the action to take.
                                                           type: object
                                                           properties:
                                                             command:
@@ -2116,7 +2155,7 @@ spec:
                                                               description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                               type: string
                                                         tcpSocket:
-                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                                           type: object
                                                           required:
                                                             - port
@@ -2131,11 +2170,11 @@ spec:
                                                                 - type: string
                                                               x-kubernetes-int-or-string: true
                                                     preStop:
-                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                                       type: object
                                                       properties:
                                                         exec:
-                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          description: Exec specifies the action to take.
                                                           type: object
                                                           properties:
                                                             command:
@@ -2181,7 +2220,7 @@ spec:
                                                               description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                               type: string
                                                         tcpSocket:
-                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                                           type: object
                                                           required:
                                                             - port
@@ -2200,7 +2239,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -2212,6 +2251,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -2262,7 +2314,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -2314,12 +2366,16 @@ spec:
                                                         description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                                         type: string
                                                         default: TCP
+                                                  x-kubernetes-list-map-keys:
+                                                    - containerPort
+                                                    - protocol
+                                                  x-kubernetes-list-type: map
                                                 readinessProbe:
                                                   description: Probes are not allowed for ephemeral containers.
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -2331,6 +2387,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -2381,7 +2450,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -2430,10 +2499,10 @@ spec:
                                                   type: object
                                                   properties:
                                                     allowPrivilegeEscalation:
-                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
                                                       type: boolean
                                                     capabilities:
-                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       properties:
                                                         add:
@@ -2449,27 +2518,27 @@ spec:
                                                             description: Capability represent POSIX capabilities type
                                                             type: string
                                                     privileged:
-                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
                                                       type: boolean
                                                     procMount:
-                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
                                                       type: string
                                                     readOnlyRootFilesystem:
-                                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                                      description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                                       type: boolean
                                                     runAsGroup:
-                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: integer
                                                       format: int64
                                                     runAsNonRoot:
                                                       description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                                       type: boolean
                                                     runAsUser:
-                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: integer
                                                       format: int64
                                                     seLinuxOptions:
-                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       properties:
                                                         level:
@@ -2485,7 +2554,7 @@ spec:
                                                           description: User is a SELinux user label that applies to the container.
                                                           type: string
                                                     seccompProfile:
-                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       required:
                                                         - type
@@ -2497,7 +2566,7 @@ spec:
                                                           description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
                                                           type: string
                                                     windowsOptions:
-                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
                                                       type: object
                                                       properties:
                                                         gmsaCredentialSpec:
@@ -2517,7 +2586,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -2529,6 +2598,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -2579,7 +2661,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -2608,7 +2690,7 @@ spec:
                                                   description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                                   type: boolean
                                                 targetContainerName:
-                                                  description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+                                                  description: "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. \n The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined."
                                                   type: string
                                                 terminationMessagePath:
                                                   description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
@@ -2636,7 +2718,7 @@ spec:
                                                         description: name must match the name of a persistentVolumeClaim in the pod
                                                         type: string
                                                 volumeMounts:
-                                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                                  description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                                   type: array
                                                   items:
                                                     description: VolumeMount describes a mounting of a Volume within a container.
@@ -2847,7 +2929,7 @@ spec:
                                                       type: object
                                                       properties:
                                                         exec:
-                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          description: Exec specifies the action to take.
                                                           type: object
                                                           properties:
                                                             command:
@@ -2893,7 +2975,7 @@ spec:
                                                               description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                               type: string
                                                         tcpSocket:
-                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                                           type: object
                                                           required:
                                                             - port
@@ -2908,11 +2990,11 @@ spec:
                                                                 - type: string
                                                               x-kubernetes-int-or-string: true
                                                     preStop:
-                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                                       type: object
                                                       properties:
                                                         exec:
-                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          description: Exec specifies the action to take.
                                                           type: object
                                                           properties:
                                                             command:
@@ -2958,7 +3040,7 @@ spec:
                                                               description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                               type: string
                                                         tcpSocket:
-                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                                           type: object
                                                           required:
                                                             - port
@@ -2977,7 +3059,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -2989,6 +3071,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -3039,7 +3134,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -3100,7 +3195,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -3112,6 +3207,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -3162,7 +3270,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -3211,10 +3319,10 @@ spec:
                                                   type: object
                                                   properties:
                                                     allowPrivilegeEscalation:
-                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
                                                       type: boolean
                                                     capabilities:
-                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       properties:
                                                         add:
@@ -3230,27 +3338,27 @@ spec:
                                                             description: Capability represent POSIX capabilities type
                                                             type: string
                                                     privileged:
-                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
                                                       type: boolean
                                                     procMount:
-                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
                                                       type: string
                                                     readOnlyRootFilesystem:
-                                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                                      description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                                       type: boolean
                                                     runAsGroup:
-                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: integer
                                                       format: int64
                                                     runAsNonRoot:
                                                       description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                                       type: boolean
                                                     runAsUser:
-                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: integer
                                                       format: int64
                                                     seLinuxOptions:
-                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       properties:
                                                         level:
@@ -3266,7 +3374,7 @@ spec:
                                                           description: User is a SELinux user label that applies to the container.
                                                           type: string
                                                     seccompProfile:
-                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                                       type: object
                                                       required:
                                                         - type
@@ -3278,7 +3386,7 @@ spec:
                                                           description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
                                                           type: string
                                                     windowsOptions:
-                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
                                                       type: object
                                                       properties:
                                                         gmsaCredentialSpec:
@@ -3298,7 +3406,7 @@ spec:
                                                   type: object
                                                   properties:
                                                     exec:
-                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      description: Exec specifies the action to take.
                                                       type: object
                                                       properties:
                                                         command:
@@ -3310,6 +3418,19 @@ spec:
                                                       description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                                       type: integer
                                                       format: int32
+                                                    grpc:
+                                                      description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        port:
+                                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                          type: integer
+                                                          format: int32
+                                                        service:
+                                                          description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                                          type: string
                                                     httpGet:
                                                       description: HTTPGet specifies the http request to perform.
                                                       type: object
@@ -3360,7 +3481,7 @@ spec:
                                                       type: integer
                                                       format: int32
                                                     tcpSocket:
-                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      description: TCPSocket specifies an action involving a TCP port.
                                                       type: object
                                                       required:
                                                         - port
@@ -3453,6 +3574,15 @@ spec:
                                             additionalProperties:
                                               type: string
                                             x-kubernetes-map-type: atomic
+                                          os:
+                                            description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                                            type: object
+                                            required:
+                                              - name
+                                            properties:
+                                              name:
+                                                description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
+                                                type: string
                                           overhead:
                                             description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
                                             type: object
@@ -3498,25 +3628,25 @@ spec:
                                             type: object
                                             properties:
                                               fsGroup:
-                                                description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
+                                                description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows."
                                                 type: integer
                                                 format: int64
                                               fsGroupChangePolicy:
-                                                description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.'
+                                                description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.'
                                                 type: string
                                               runAsGroup:
-                                                description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                                description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
                                                 type: integer
                                                 format: int64
                                               runAsNonRoot:
                                                 description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                                 type: boolean
                                               runAsUser:
-                                                description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                                description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
                                                 type: integer
                                                 format: int64
                                               seLinuxOptions:
-                                                description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                                description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
                                                 type: object
                                                 properties:
                                                   level:
@@ -3532,7 +3662,7 @@ spec:
                                                     description: User is a SELinux user label that applies to the container.
                                                     type: string
                                               seccompProfile:
-                                                description: The seccomp options to use by the containers in this pod.
+                                                description: The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
                                                 type: object
                                                 required:
                                                   - type
@@ -3544,13 +3674,13 @@ spec:
                                                     description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
                                                     type: string
                                               supplementalGroups:
-                                                description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                                                description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.
                                                 type: array
                                                 items:
                                                   type: integer
                                                   format: int64
                                               sysctls:
-                                                description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                                                description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.
                                                 type: array
                                                 items:
                                                   description: Sysctl defines a kernel parameter to be set
@@ -3566,7 +3696,7 @@ spec:
                                                       description: Value of a property to set
                                                       type: string
                                               windowsOptions:
-                                                description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
                                                 type: object
                                                 properties:
                                                   gmsaCredentialSpec:
@@ -3672,7 +3802,7 @@ spec:
                                                   description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                                   type: string
                                                 whenUnsatisfiable:
-                                                  description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                                  description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                                   type: string
                                             x-kubernetes-list-map-keys:
                                               - topologyKey
@@ -3930,7 +4060,7 @@ spec:
                                                         - type: string
                                                       x-kubernetes-int-or-string: true
                                                 ephemeral:
-                                                  description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time. \n This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                                                  description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                                                   type: object
                                                   properties:
                                                     volumeClaimTemplate:
@@ -3968,7 +4098,7 @@ spec:
                                                                   description: Name is the name of resource being referenced
                                                                   type: string
                                                             dataSourceRef:
-                                                              description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                                              description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                                               type: object
                                                               required:
                                                                 - kind
@@ -3984,7 +4114,7 @@ spec:
                                                                   description: Name is the name of resource being referenced
                                                                   type: string
                                                             resources:
-                                                              description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                              description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                               type: object
                                                               properties:
                                                                 limits:
@@ -4632,7 +4762,7 @@ spec:
                                       items:
                                         type: string
                                     verbs:
-                                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
+                                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
                                       type: array
                                       items:
                                         type: string
@@ -4689,7 +4819,7 @@ spec:
                 nativeAPIs:
                   type: array
                   items:
-                    description: GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling
+                    description: GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
                     type: object
                     required:
                       - group
@@ -4761,7 +4891,6 @@ spec:
                   items:
                     type: string
                 version:
-                  description: OperatorVersion is a wrapper around semver.Version which supports correct marshaling to YAML and JSON.
                   type: string
                 webhookdefinitions:
                   type: array

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-installplans.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-installplans.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: installplans.operators.coreos.com
 spec:
@@ -222,6 +222,8 @@ spec:
                       - resource
                       - status
                     properties:
+                      optional:
+                        type: boolean
                       resolving:
                         type: string
                       resource:

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-olmconfigs.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-olmconfigs.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: olmconfigs.operators.coreos.com
 spec:
@@ -50,7 +50,7 @@ spec:
                 conditions:
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - lastTransitionTime

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-operatorconditions.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: operatorconditions.operators.coreos.com
 spec:
@@ -45,7 +45,7 @@ spec:
                 overrides:
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - message
@@ -95,7 +95,7 @@ spec:
                 conditions:
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - lastTransitionTime
@@ -162,7 +162,7 @@ spec:
                 conditions:
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - lastTransitionTime
@@ -209,7 +209,7 @@ spec:
                 overrides:
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - message
@@ -259,7 +259,7 @@ spec:
                 conditions:
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - lastTransitionTime

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-operatorgroups.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: operatorgroups.operators.coreos.com
 spec:
@@ -90,7 +90,7 @@ spec:
                   description: Conditions is an array of the OperatorGroup's conditions.
                   type: array
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     type: object
                     required:
                       - lastTransitionTime

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-operators.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-operators.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: operators.operators.coreos.com
 spec:

--- a/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-subscriptions.crd.yaml
+++ b/modules/operator-lifecycle-manager/chart/crds/0000_50_olm_00-subscriptions.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: subscriptions.operators.coreos.com
 spec:
@@ -533,7 +533,7 @@ spec:
                                   - type: string
                                 x-kubernetes-int-or-string: true
                           ephemeral:
-                            description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time. \n This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                            description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                             type: object
                             properties:
                               volumeClaimTemplate:
@@ -571,7 +571,7 @@ spec:
                                             description: Name is the name of resource being referenced
                                             type: string
                                       dataSourceRef:
-                                        description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                        description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                         type: object
                                         required:
                                           - kind
@@ -587,7 +587,7 @@ spec:
                                             description: Name is the name of resource being referenced
                                             type: string
                                       resources:
-                                        description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         type: object
                                         properties:
                                           limits:

--- a/modules/operator-lifecycle-manager/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/modules/operator-lifecycle-manager/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -18,48 +18,79 @@ spec:
         app: catalog-operator
     spec:
       serviceAccountName: olm-operator-serviceaccount
+      {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
+      volumes:
+      {{- end }}
+      {{- if .Values.catalog.tlsSecret }}
+      - name: srv-cert
+        secret:
+          secretName: {{ .Values.catalog.tlsSecret }}
+      {{- end }}
+      {{- if .Values.catalog.clientCASecret }}
+      - name: profile-collector-cert
+        secret:
+          secretName: {{ .Values.catalog.clientCASecret }}
+      {{- end }}
       containers:
         - name: catalog-operator
+          {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
+          volumeMounts:
+          {{- end }}
+          {{- if .Values.catalog.tlsSecret }}
+          - name: srv-cert
+            mountPath: "/srv-cert"
+            readOnly: true
+          {{- end }}
+          {{- if .Values.catalog.clientCASecret }}
+          - name: profile-collector-cert
+            mountPath: "/profile-collector-cert"
+            readOnly: true
+          {{- end }}
           command:
           - /bin/catalog
           args:
-          - '-namespace'
+          - '--namespace'
           - {{ .Values.catalog_namespace }}
           {{- if .Values.debug }}
-          - '-debug'
+          - '--debug'
           {{- end }}
           {{- if .Values.catalog.commandArgs }}
           - {{ .Values.catalog.commandArgs }}
           {{- end }}
-          - -util-image
+          {{- if .Values.catalog.opmImageArgs }}
+          - {{ .Values.catalog.opmImageArgs }}
+          {{- end }}
+          - --util-image
           -  {{ .Values.catalog.image.ref }}
           {{- if .Values.writeStatusNameCatalog }}
-          - -writeStatusName
+          - --writeStatusName
           - {{ .Values.writeStatusNameCatalog }}
           {{- end }}
-          {{- if .Values.olm.tlsCertPath }}
-          - -tls-cert
-          - {{ .Values.olm.tlsCertPath }}
+          {{- if .Values.catalog.tlsSecret }}
+          - --tls-cert
+          - /srv-cert/tls.crt
+          - --tls-key
+          - /srv-cert/tls.key
           {{- end }}
-          {{- if .Values.olm.tlsKeyPath }}
-          - -tls-key
-          - {{ .Values.olm.tlsKeyPath }}
+          {{- if .Values.catalog.clientCASecret }}
+          - --client-ca
+          - /profile-collector-cert/tls.crt
           {{- end }}
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.catalog.service.internalPort }}
-            - containerPort: 8081
+            - containerPort: {{ .Values.olm.service.internalPort }}
               name: metrics
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
+              scheme: {{ if .Values.catalog.tlsSecret }}HTTPS{{ else }}HTTP{{end}}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
+              scheme: {{ if .Values.catalog.tlsSecret }}HTTPS{{ else }}HTTP{{end}}
           terminationMessagePolicy: FallbackToLogsOnError
           {{- if .Values.catalog.resources }}
           resources:

--- a/modules/operator-lifecycle-manager/chart/values.yaml
+++ b/modules/operator-lifecycle-manager/chart/values.yaml
@@ -14,27 +14,33 @@ olm:
     pullPolicy: Always
   service:
     internalPort: 8080
+    externalPort: metrics
+  # tlsSecret: olm-operator-serving-cert
+  # clientCASecret: pprof-serving-cert
   nodeSelector:
     kubernetes.io/os: linux
   resources:
     requests:
-     cpu: 20m
-     memory: 320Mi
+     cpu: 10m
+     memory: 160Mi
 
 catalog:
   replicaCount: 1
-  commandArgs: -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
+  commandArgs: --configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
   image:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always
   service:
     internalPort: 8080
+    externalPort: metrics
+  # tlsSecret: catalog-operator-serving-cert
+  # clientCASecret: pprof-serving-cert
   nodeSelector:
     kubernetes.io/os: linux
   resources:
     requests:
-     cpu: 20m
-     memory: 160Mi
+     cpu: 10m
+     memory: 80Mi
 
 package:
   replicaCount: 2
@@ -49,8 +55,8 @@ package:
     kubernetes.io/os: linux
   resources:
     requests:
-     cpu: 20m
-     memory: 100Mi
+     cpu: 10m
+     memory: 50Mi
 
 monitoring:
   enabled: false


### PR DESCRIPTION
The OLM project recently switched to using Cobra for CLI flag management. This changed the command arguments for the catalog container to be double hyphenated `'--'` instead of single `'-'`, resulting in the following error from the `catalog-operator` deployment:

```
│ Error: unknown shorthand flag: 'n' in -namespace 
```

We use the master/latest tag for the operator-framework/olm image, which was no longer compatible with our helm chart configuration. This update brings in those changes, along with a minor update to the CRDs