### PR TITLE
Update to default prometheus behavior

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,9 @@ locals {
     grafana = {
       enabled = false
     }
+    prometheus = {
+      enabled = false
+    }
   })]
 }
 

--- a/modules/prometheus-operator/main.tf
+++ b/modules/prometheus-operator/main.tf
@@ -32,7 +32,7 @@ locals {
   atomic           = var.atomic != null ? var.atomic : true
   chart_name       = var.chart_name != null ? var.chart_name : "kube-prometheus-stack"
   chart_repository = var.chart_repository != null ? var.chart_repository : "https://prometheus-community.github.io/helm-charts"
-  chart_version    = var.chart_version != null ? var.chart_version : "21.0.0"
+  chart_version    = var.chart_version != null ? var.chart_version : "33.2.1"
   cleanup_on_fail  = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
   create_namespace = var.create_namespace != null ? var.create_namespace : true
   namespace        = var.namespace != null ? var.namespace : "monitoring"


### PR DESCRIPTION
## Overview
This PR disabled a prometheus server from being installed by default via the `kube-prometheus-stack` helm chart. For the time being, the only components we need installed from this chart are:

- Prometheus Operator
- Node Exporter
- Alert Manager

## Additional changes
Updated the `kube-prometheus-stack` helm chart to a [newer version](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). For existing environments wishing to upgrade to the latest upcoming release of `terraform-helm-charts`, the [CRDs will need to be manually updated](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-31x-to-32x).