### PR TITLE
Support to specify  subscription resources

### DIFF
--- a/modules/olm-subscriptions/README.md
+++ b/modules/olm-subscriptions/README.md
@@ -78,6 +78,10 @@ No modules.
 | <a name="input_registry"></a> [registry](#input\_registry) | The registry containing StreamNative's operator catalog images. This is required. | `string` | n/a | yes |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | The name of the helm release. | `string` | `null` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values. | `map(any)` | `null` | no |
+| <a name="input_subscription_cpu_limits"></a> [subscription\_cpu\_limits](#input\_subscription\_cpu\_limits) | The cpu limits of subscription. | `string` | `null` | no |
+| <a name="input_subscription_cpu_requests"></a> [subscription\_cpu\_requests](#input\_subscription\_cpu\_requests) | The cpu requests of subscription. | `string` | `null` | no |
+| <a name="input_subscription_mem_limits"></a> [subscription\_mem\_limits](#input\_subscription\_mem\_limits) | The mem limits of subscription. | `string` | `null` | no |
+| <a name="input_subscription_mem_requests"></a> [subscription\_mem\_requests](#input\_subscription\_mem\_requests) | The mem requests of subscription. | `string` | `null` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation. | `number` | `null` | no |
 | <a name="input_values"></a> [values](#input\_values) | A list of values in raw YAML to be applied to the helm release. Merges with the settings input, can also be used with the `file()` function, i.e. `file("my/values.yaml")`. | `any` | `null` | no |
 | <a name="input_enable_sn_operator"></a> [enable\_sn\_operator](#input\_enable\_sn\_operator) | Whether to enable SN Operator | `bool` | `"false"` | no |

--- a/modules/olm-subscriptions/chart/templates/_helper.tpl
+++ b/modules/olm-subscriptions/chart/templates/_helper.tpl
@@ -1,0 +1,89 @@
+{{/*
+Get subscription config for bookkeeper
+*/}}
+{{- define "subscription.bookkeeperResources" -}}
+{{- if .Values.bookkeeper.config.resources }}
+  {{- toYaml .Values.bookkeeper.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Get subscription config for flink
+*/}}
+{{- define "subscription.flinkResources" -}}
+{{- if .Values.flink.config.resources }}
+  {{- toYaml .Values.flink.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get subscription config for flink sql
+*/}}
+{{- define "subscription.flinkSQLResources" -}}
+{{- if .Values.flinkSql.config.resources }}
+  {{- toYaml .Values.flinkSql.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get subscription config for function mesh
+*/}}
+{{- define "subscription.functionMeshResources" -}}
+{{- if .Values.functionMesh.config.resources }}
+  {{- toYaml .Values.functionMesh.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get subscription config for prometheus
+*/}}
+{{- define "subscription.prometheusResources" -}}
+{{- if .Values.prometheus.config.resources }}
+  {{- toYaml .Values.prometheus.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Get subscription config for pulsar
+*/}}
+{{- define "subscription.pulsarResources" -}}
+{{- if .Values.pulsar.config.resources }}
+  {{- toYaml .Values.pulsar.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get subscription config for sn-operator
+*/}}
+{{- define "subscription.snOperatorResources" -}}
+{{- if .Values.sn_operator.config.resources }}
+  {{- toYaml .Values.sn_operator.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get subscription config for zookeeper
+*/}}
+{{- define "subscription.zookeeperResources" -}}
+{{- if .Values.zookeeper.config.resources }}
+  {{- toYaml .Values.zookeeper.config.resources | nindent 6 }}
+{{- else }}
+  {{- toYaml .Values.subscriptionConfig.resources | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/modules/olm-subscriptions/chart/templates/bookkeeper.yaml
+++ b/modules/olm-subscriptions/chart/templates/bookkeeper.yaml
@@ -29,7 +29,8 @@ spec:
   source: {{ .Values.bookkeeper.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.bookkeeper.name }}
-
+  config:
+    resources: {{ include "subscription.bookkeeperResources" . }}
 ---
 {{- if and .Values.istio.enabled }}
 apiVersion: security.istio.io/v1beta1

--- a/modules/olm-subscriptions/chart/templates/flink.yaml
+++ b/modules/olm-subscriptions/chart/templates/flink.yaml
@@ -29,4 +29,6 @@ spec:
   source: {{ .Values.flink.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.flink.name }}
+  config:
+    resources: {{ include "subscription.flinkResources" . }}
 {{- end }}

--- a/modules/olm-subscriptions/chart/templates/flinksql.yaml
+++ b/modules/olm-subscriptions/chart/templates/flinksql.yaml
@@ -29,4 +29,6 @@ spec:
   source: {{ .Values.flinkSql.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.flinkSql.name }}
+  config:
+    resources: {{ include "subscription.flinkSQLResources" . }}
 {{- end }}

--- a/modules/olm-subscriptions/chart/templates/functionmesh.yaml
+++ b/modules/olm-subscriptions/chart/templates/functionmesh.yaml
@@ -31,6 +31,7 @@ spec:
       value: "{{ .Values.functionMesh.config.enableWebhooks }}"
     - name: ENABLE_FUNCTION_MESH_CONTROLLER
       value: "{{ .Values.functionMesh.config.enableController }}"
+    resources: {{ include "subscription.functionMeshResources" . }}
   installPlanApproval: {{ .Values.functionMesh.approval | default .Values.approval }}  
   source: {{ .Values.functionMesh.source }}
   sourceNamespace: {{ .Values.olm_namespace }}

--- a/modules/olm-subscriptions/chart/templates/prometheus.yaml
+++ b/modules/olm-subscriptions/chart/templates/prometheus.yaml
@@ -29,4 +29,6 @@ spec:
   source: {{ .Values.prometheus.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.prometheus.name }}
+  config:
+    resources: {{ include "subscription.prometheusResources" . }}
 {{- end }}

--- a/modules/olm-subscriptions/chart/templates/pulsar.yaml
+++ b/modules/olm-subscriptions/chart/templates/pulsar.yaml
@@ -29,6 +29,8 @@ spec:
   source: {{ .Values.pulsar.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.pulsar.name }}
+  config:
+    resources: {{ include "subscription.pulsarResources" . }}
 
 ---
 {{- if and .Values.istio.enabled }}

--- a/modules/olm-subscriptions/chart/templates/sn-operator.yaml
+++ b/modules/olm-subscriptions/chart/templates/sn-operator.yaml
@@ -29,4 +29,6 @@ spec:
   source: {{ .Values.sn_operator.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.sn_operator.name }}
+  config:
+    resources: {{ include "subscription.snOperatorResources" . }}
 {{- end }}

--- a/modules/olm-subscriptions/chart/templates/zookeeper.yaml
+++ b/modules/olm-subscriptions/chart/templates/zookeeper.yaml
@@ -29,6 +29,8 @@ spec:
   source: {{ .Values.zookeeper.source }}
   sourceNamespace: {{ .Values.olm_namespace }}
   name: {{ .Values.zookeeper.name }}
+  config:
+    resources: {{ include "subscription.zookeeperResources" . }}
 
 ---
 {{- if and .Values.istio.enabled }}

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -39,17 +39,30 @@ components:
   zookeeper: true
   sn_operator: true
 
+subscriptionConfig:
+  resources:
+    requests:
+      cpu: 20m
+      mem: 16Mi
+    limits:
+      cpu: 200m
+      mem: 256Mi
+
+
 bookkeeper:
   source: sn-catalog
   name: bookkeeper-operator
+  config: {}
 
 flink:
   source: sn-catalog
   name: flink-operator
+  config: {}
 
 flinkSql:
   source: sn-catalog
   name: sql-operator
+  config: {}
 
 functionMesh:
   config:
@@ -62,15 +75,19 @@ prometheus:
   channel: beta
   source: operatorhubio-catalog
   name: prometheus
+  config: {}
 
 pulsar:
   source: sn-catalog
   name: pulsar-operator
+  config: {}
 
 zookeeper:
   source: sn-catalog
   name: zookeeper-operator
+  config: {}
 
 sn_operator:
   source: sn-catalog
   name: sn-operator
+  config: {}

--- a/modules/olm-subscriptions/chart/values.yaml
+++ b/modules/olm-subscriptions/chart/values.yaml
@@ -43,10 +43,10 @@ subscriptionConfig:
   resources:
     requests:
       cpu: 20m
-      mem: 16Mi
+      memory: 16Mi
     limits:
       cpu: 200m
-      mem: 256Mi
+      memory: 256Mi
 
 
 bookkeeper:

--- a/modules/olm-subscriptions/main.tf
+++ b/modules/olm-subscriptions/main.tf
@@ -27,21 +27,26 @@ terraform {
     }
   }
 }
+
 locals {
-  atomic                 = var.atomic != null ? var.atomic : true
-  chart_name             = var.chart_name != null ? var.chart_name : "${path.module}/chart"
-  chart_repository       = var.chart_repository != null ? var.chart_repository : null
-  chart_version          = var.chart_version != null ? var.chart_version : null
-  cleanup_on_fail        = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
-  install_namespace      = var.install_namespace != null ? var.install_namespace : "sn-system"
-  olm_namespace          = var.olm_namespace != null ? var.olm_namespace : "olm"
-  release_name           = var.release_name != null ? var.release_name : "olm-subscriptions"
-  enable_istio           = var.enable_istio != null ? var.enable_istio : false
-  istio_system_namespace = var.istio_system_namespace != null ? var.istio_system_namespace : "istio-system"
-  channel                = var.channel != null ? var.channel : "stable"
-  settings               = var.settings != null ? var.settings : {}
-  timeout                = var.timeout != null ? var.timeout : 120
-  values                 = var.values != null ? var.values : []
+  atomic                    = var.atomic != null ? var.atomic : true
+  chart_name                = var.chart_name != null ? var.chart_name : "${path.module}/chart"
+  chart_repository          = var.chart_repository != null ? var.chart_repository : null
+  chart_version             = var.chart_version != null ? var.chart_version : null
+  cleanup_on_fail           = var.cleanup_on_fail != null ? var.cleanup_on_fail : true
+  install_namespace         = var.install_namespace != null ? var.install_namespace : "sn-system"
+  olm_namespace             = var.olm_namespace != null ? var.olm_namespace : "olm"
+  release_name              = var.release_name != null ? var.release_name : "olm-subscriptions"
+  enable_istio              = var.enable_istio != null ? var.enable_istio : false
+  istio_system_namespace    = var.istio_system_namespace != null ? var.istio_system_namespace : "istio-system"
+  channel                   = var.channel != null ? var.channel : "stable"
+  settings                  = var.settings != null ? var.settings : {}
+  timeout                   = var.timeout != null ? var.timeout : 120
+  values                    = var.values != null ? var.values : []
+  subscription_cpu_requests = var.subscription_cpu_requests != null ? var.subscription_cpu_requests : "20m"
+  subscription_mem_requests = var.subscription_mem_requests != null ? var.subscription_mem_requests : "16Mi"
+  subscription_cpu_limits   = var.subscription_cpu_limits != null ? var.subscription_cpu_limits : "200m"
+  subscription_mem_limits   = var.subscription_mem_limits != null ? var.subscription_mem_limits : "256Mi"
 }
 
 resource "helm_release" "olm_subscriptions" {
@@ -82,6 +87,30 @@ resource "helm_release" "olm_subscriptions" {
   set {
     name  = "istio.rootNamespace"
     value = local.istio_system_namespace
+    type  = "string"
+  }
+
+  set {
+    name  = "subscriptionConfig.resources.requests.cpu"
+    value = local.subscription_cpu_requests
+    type  = "string"
+  }
+
+  set {
+    name  = "subscriptionConfig.resources.requests.mem"
+    value = local.subscription_mem_requests
+    type  = "string"
+  }
+
+  set {
+    name  = "subscriptionConfig.resources.limits.cpu"
+    value = local.subscription_cpu_limits
+    type  = "string"
+  }
+
+  set {
+    name  = "subscriptionConfig.resources.limits.mem"
+    value = local.subscription_mem_limits
     type  = "string"
   }
 

--- a/modules/olm-subscriptions/main.tf
+++ b/modules/olm-subscriptions/main.tf
@@ -97,7 +97,7 @@ resource "helm_release" "olm_subscriptions" {
   }
 
   set {
-    name  = "subscriptionConfig.resources.requests.mem"
+    name  = "subscriptionConfig.resources.requests.memory"
     value = local.subscription_mem_requests
     type  = "string"
   }
@@ -109,7 +109,7 @@ resource "helm_release" "olm_subscriptions" {
   }
 
   set {
-    name  = "subscriptionConfig.resources.limits.mem"
+    name  = "subscriptionConfig.resources.limits.memory"
     value = local.subscription_mem_limits
     type  = "string"
   }

--- a/modules/olm-subscriptions/variables.tf
+++ b/modules/olm-subscriptions/variables.tf
@@ -104,3 +104,27 @@ variable "values" {
   default     = null
   description = "A list of values in raw YAML to be applied to the helm release. Merges with the settings input, can also be used with the `file()` function, i.e. `file(\"my/values.yaml\")`."
 }
+
+variable "subscription_cpu_requests" {
+  default     = null
+  description = "The cpu requests of subscription."
+  type        = string
+}
+
+variable "subscription_mem_requests" {
+  default     = null
+  description = "The mem requests of subscription."
+  type        = string
+}
+
+variable "subscription_cpu_limits" {
+  default     = null
+  description = "The cpu limits of subscription."
+  type        = string
+}
+
+variable "subscription_mem_limits" {
+  default     = null
+  description = "The mem limits of subscription."
+  type        = string
+}


### PR DESCRIPTION
# Motivation
Allow specifying the resources of the operator by setting the config of the subscription.
Resolve https://github.com/streamnative/sn-operators-catalog/issues/24