### PR TITLE
[istio-operator] Add default sidecar annotation for autoscaler to handle eviction properly

### DIFF
--- a/modules/istio-operator/values.yaml.tpl
+++ b/modules/istio-operator/values.yaml.tpl
@@ -12,6 +12,8 @@ controlPlane:
           clusterName: ${cluster_name}
         network: ${network}
       sidecarInjectorWebhook:
+        injectedAnnotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         neverInjectSelector:
           # kube-prometheus-stack
           ## Admission Webhook jobs do not terminate as expected with istio-proxy


### PR DESCRIPTION
## Overview
This PR addresses an [issue](https://github.com/istio/istio/issues/19395) where autoscaler can't evict pods on a node because of the presence of a local storage directory created by Istio.

By default, the sidecars will now have the `safe-to-evict: "true"` annotation. 