### PR TITLE
Gtoken sidecar for vmagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ No resources.
 | <a name="input_vmagent_basicauth_enabled"></a> [vmagent\_basicauth\_enabled](#input\_vmagent\_basicauth\_enabled) | Enable basic auth for remote write endpoint. Requires providing a username and base64 encoded password. | `bool` | `null` | no |
 | <a name="input_vmagent_basicauth_password"></a> [vmagent\_basicauth\_password](#input\_vmagent\_basicauth\_password) | If basic auth is enabled, provide the base64 encoded password to use for the VMAgent client connection | `string` | `null` | no |
 | <a name="input_vmagent_basicauth_username"></a> [vmagent\_basicauth\_username](#input\_vmagent\_basicauth\_username) | If basic auth is enabled, provate the username for the VMAgent client | `string` | `null` | no |
+| <a name="input_vmagent_gsa_audience"></a> [vmagent\_gsa\_audience](#input\_vmagent\_gsa\_audience) | If using GSA for auth to send metrics, the audience to use for token generation | `string` | `null` | no |
 | <a name="input_vmagent_chart_name"></a> [vmagent\_chart\_name](#input\_vmagent\_chart\_name) | The name of the Helm chart to install | `string` | `null` | no |
 | <a name="input_vmagent_chart_repository"></a> [vmagent\_chart\_repository](#input\_vmagent\_chart\_repository) | The repository containing the Helm chart to install. | `string` | `null` | no |
 | <a name="input_vmagent_chart_version"></a> [vmagent\_chart\_version](#input\_vmagent\_chart\_version) | The version of the Helm chart to install. Set to the submodule default. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -206,6 +206,7 @@ module "vmagent" {
   basicauth_enabled      = var.vmagent_basicauth_enabled
   basicauth_username     = var.vmagent_basicauth_username
   basicauth_password     = var.vmagent_basicauth_password
+  gsa_audience           = var.vmagent_gsa_audience
   chart_name             = var.vmagent_chart_name
   chart_repository       = var.vmagent_chart_repository
   chart_version          = var.vmagent_chart_version

--- a/modules/victoria-metrics-agent/README.md
+++ b/modules/victoria-metrics-agent/README.md
@@ -32,6 +32,7 @@ No modules.
 | <a name="input_basicauth_enabled"></a> [basicauth\_enabled](#input\_basicauth\_enabled) | Enable basic auth for remote write endpoint. Requires providing a username and base64 encoded password. | `bool` | `null` | no |
 | <a name="input_basicauth_password"></a> [basicauth\_password](#input\_basicauth\_password) | If basic auth is enabled, provide the base64 encoded password to use for the VMAgent client connection | `string` | `null` | no |
 | <a name="input_basicauth_username"></a> [basicauth\_username](#input\_basicauth\_username) | If basic auth is enabled, provate the username for the VMAgent client | `string` | `null` | no |
+| <a name="input_gsa_audience"></a> [gsa\_audience](#input\_gsa\_audience) | If using GSA for auth to send metrics, the audience to use for token generation | `string` | `null` | no |
 | <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | The name of the Helm chart to install. Refer to https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-agent | `string` | `null` | no |
 | <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | The repository containing the Helm chart to install. | `string` | `null` | no |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | The version of the Helm chart to install. | `string` | `null` | no |

--- a/modules/victoria-metrics-agent/main.tf
+++ b/modules/victoria-metrics-agent/main.tf
@@ -44,6 +44,7 @@ locals {
 
   basicauth_enabled         = var.basicauth_enabled != null ? var.basicauth_enabled : false
   basicauth_password        = var.basicauth_password != null ? var.basicauth_password : ""
+  gsa_audience              = var.gsa_audience != null ? var.gsa_audience : ""
   basicauth_username        = var.basicauth_username != null ? var.basicauth_username : ""
   oauth2_enabled            = var.oauth2_enabled != null ? var.oauth2_enabled : false
   oauth2_client_id          = var.oauth2_client_id != null ? var.oauth2_client_id : ""
@@ -67,6 +68,7 @@ resource "helm_release" "vmagent" {
     basicauth_enabled         = local.basicauth_enabled
     basicauth_password        = base64decode(local.basicauth_password)
     basicauth_username        = local.basicauth_username
+    gsa_audience              = local.gsa_audience
     oauth2_enabled            = local.oauth2_enabled
     oauth2_client_id          = local.oauth2_client_id
     oauth2_client_secret      = base64decode(local.oauth2_client_secret)

--- a/modules/victoria-metrics-agent/values.yaml.tftpl
+++ b/modules/victoria-metrics-agent/values.yaml.tftpl
@@ -41,6 +41,37 @@ extraArgs:
   # promscrape.maxScrapeSize: "167772160"
   promscrape.suppressDuplicateScrapeTargetErrors: "true"
 
+extraVolumeMounts:
+- mountPath: /shared
+  name: shared-token
+
+extraVolumes:
+  - name: vmagent-gsa
+    secret:
+      optional: true
+      secretName: vmagent-gsa
+      items:
+      - key: client
+        path: client.json
+  - name: shared-token
+    emptyDir: {}
+
+extraContainers:
+  - name: gtoken
+    image: "docker.cloudsmith.io/streamnative/cloud-tools/gtoken:v1.10.0"
+    args: [
+      "--key-file", "/keys/client.json",
+      "--token-file", "/shared/token.dat",
+      "--audience", "\"192559831372-3b3q95dldr0qt7sq6isv2gigul2heous.apps.googleusercontent.com\""
+      "--ignore-missing-key-file"
+    ]
+    volumeMounts:
+    - mountPath: /keys
+      name: vmagent-gsa
+      readOnly: true
+    - mountPath: /shared
+      name: shared-token
+
 config:
   global:
     scrape_interval: 30s

--- a/modules/victoria-metrics-agent/values.yaml.tftpl
+++ b/modules/victoria-metrics-agent/values.yaml.tftpl
@@ -63,7 +63,7 @@ extraContainers:
     args: [
       "--key-file", "/keys/client.json",
       "--token-file", "/shared/token.dat",
-      "--audience", "\"192559831372-3b3q95dldr0qt7sq6isv2gigul2heous.apps.googleusercontent.com\""
+      "--audience", "\"${gsa_audience}\""
       "--ignore-missing-key-file"
     ]
     volumeMounts:

--- a/modules/victoria-metrics-agent/values.yaml.tftpl
+++ b/modules/victoria-metrics-agent/values.yaml.tftpl
@@ -40,6 +40,7 @@ extraArgs:
   loggerFormat: json
   # promscrape.maxScrapeSize: "167772160"
   promscrape.suppressDuplicateScrapeTargetErrors: "true"
+  remoteWrite.bearerTokenFile: /shared/token.dat
 
 extraVolumeMounts:
 - mountPath: /shared

--- a/modules/victoria-metrics-agent/values.yaml.tftpl
+++ b/modules/victoria-metrics-agent/values.yaml.tftpl
@@ -52,8 +52,8 @@ extraVolumes:
       optional: true
       secretName: vmagent-gsa
       items:
-      - key: client
-        path: client.json
+      - key: credentials.json
+        path: credentials.json
   - name: shared-token
     emptyDir: {}
 
@@ -61,7 +61,7 @@ extraContainers:
   - name: gtoken
     image: "docker.cloudsmith.io/streamnative/cloud-tools/gtoken:v1.10.0"
     args: [
-      "--key-file", "/keys/client.json",
+      "--key-file", "/keys/credentials.json",
       "--token-file", "/shared/token.dat",
       "--audience", "\"${gsa_audience}\""
       "--ignore-missing-key-file"

--- a/modules/victoria-metrics-agent/variables.tf
+++ b/modules/victoria-metrics-agent/variables.tf
@@ -64,6 +64,13 @@ variable "basicauth_password" {
   type        = string
 }
 
+variable "gsa_audience" {
+  default     = null
+  description = "If using GSA for auth to send metrics, the audience to use for token generation"
+  sensitive   = true
+  type        = string
+}
+
 variable "create_namespace" {
   default     = null
   description = "Create a namespace for the deployment."

--- a/variables.tf
+++ b/variables.tf
@@ -741,6 +741,13 @@ variable "vmagent_basicauth_password" {
   type        = string
 }
 
+variable "vmagent_gsa_audience" {
+  default     = null
+  description = "If using GSA for auth to send metrics, the audience to use for token generation"
+  sensitive   = true
+  type        = string
+}
+
 variable "vmagent_chart_name" {
   default     = null
   description = "The name of the Helm chart to install"


### PR DESCRIPTION
Related to https://github.com/streamnative/cloud-api-server/pull/1106

There is a sidecar for gtoken that has a secret volume mounted into it. The secret is a key file for a GSA. The gtoken sidecar generates a token and then stores it into a volume shared with the vmagent container. (Not implemented yet) The vmagent container will use this token to make requests to the unified metrics stack.