### PR TITLE
Add Option To Configure Istio Service Annotations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,10 +126,10 @@ module "cloud-manager-agent" {
   count  = var.enable_cma ? 1 : 0
   source = "./modules/cloud-manager-agent"
 
-  namespace              = var.cma_namespace
-  settings               = var.cma_settings
-  environment            = var.cma_environment
-  values                 = var.cma_values
+  namespace   = var.cma_namespace
+  settings    = var.cma_settings
+  environment = var.cma_environment
+  values      = var.cma_values
 }
 
 locals {

--- a/modules/istio-operator/README.md
+++ b/modules/istio-operator/README.md
@@ -3,12 +3,14 @@ This is an opinionated module for installing and configuring Istio, along with t
 
 Note that this module does not install all of the services necessary for Kiali to function, such as Prometheus, Jaeger, or (in some cases) Grafana. Refer to the [official docs](https://kiali.io/docs/configuration/p8s-jaeger-grafana/) for instructions if these components do not exist on your cluster.
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.2.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >=0.7.2 |
 
 ## Providers
 
@@ -16,7 +18,7 @@ Note that this module does not install all of the services necessary for Kiali t
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | >=0.7.2 |
 
 ## Modules
 
@@ -53,6 +55,7 @@ No modules.
 | <a name="input_istio_gateway_certificate_hosts"></a> [istio\_gateway\_certificate\_hosts](#input\_istio\_gateway\_certificate\_hosts) | The certificate host(s) for the Istio gateway TLS certificate. | `list(string)` | `[]` | no |
 | <a name="input_istio_gateway_certificate_issuer"></a> [istio\_gateway\_certificate\_issuer](#input\_istio\_gateway\_certificate\_issuer) | The certificate issuer for the Istio gateway TLS certificate. | <pre>object({<br>    group = string<br>    kind  = string<br>    name  = string<br>  })</pre> | `null` | no |
 | <a name="input_istio_gateway_certificate_name"></a> [istio\_gateway\_certificate\_name](#input\_istio\_gateway\_certificate\_name) | The certificate name for Istio gateway TLS. | `string` | `null` | no |
+| <a name="input_istio_ingress_gateway_service_annotations"></a> [istio\_ingress\_gateway\_service\_annotations](#input\_istio\_ingress\_gateway\_service\_annotations) | Kubernetes annotations to add to the Istio IngressGateway Service. | `map(string)` | `null` | no |
 | <a name="input_istio_mesh_id"></a> [istio\_mesh\_id](#input\_istio\_mesh\_id) | The ID used by the Istio mesh. This is also the ID of the StreamNative Cloud Pool used for the workload environment. | `string` | `null` | no |
 | <a name="input_istio_network"></a> [istio\_network](#input\_istio\_network) | The network used for the Istio mesh. | `string` | `null` | no |
 | <a name="input_istio_operator_namespace"></a> [istio\_operator\_namespace](#input\_istio\_operator\_namespace) | The namespace where the Istio Operator is installed. | `string` | `null` | no |
@@ -84,3 +87,4 @@ No modules.
 ## Outputs
 
 No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/istio-operator/main.tf
+++ b/modules/istio-operator/main.tf
@@ -27,7 +27,7 @@ terraform {
     }
 
     time = {
-      source = "hashicorp/time"
+      source  = "hashicorp/time"
       version = ">=0.7.2"
     }
   }
@@ -40,22 +40,23 @@ locals {
   timeout         = var.timeout != null ? var.timeout : 120
 
   # Istio Operator Settings
-  create_istio_system_namespace   = var.create_istio_system_namespace != null ? var.create_istio_system_namespace : true
-  create_istio_operator_namespace = var.create_istio_operator_namespace != null ? var.create_istio_operator_namespace : true
-  istio_chart_name                = var.istio_chart_name != null ? var.istio_chart_name : "istio-operator"
-  istio_chart_repository          = var.istio_chart_repository != null ? var.istio_chart_repository : "https://stevehipwell.github.io/helm-charts/"
-  istio_chart_version             = var.istio_chart_version != null ? var.istio_chart_version : "2.4.0"
-  istio_cluster_name              = var.istio_cluster_name != null ? var.istio_cluster_name : null
-  istio_mesh_id                   = var.istio_mesh_id != null ? var.istio_mesh_id : null
-  istio_network                   = var.istio_network != null ? var.istio_network : "network1"
-  istio_operator_namespace        = var.istio_operator_namespace != null ? var.istio_operator_namespace : "istio-operator"
-  istio_profile                   = var.istio_profile != null ? var.istio_profile : "default"
-  istio_release_name              = var.istio_release_name != null ? var.istio_release_name : "istio-operator"
-  istio_revision_tag              = var.istio_revision_tag != null ? var.istio_revision_tag : "default"
-  istio_settings                  = var.istio_settings != null ? var.istio_settings : {}
-  istio_system_namespace          = var.istio_system_namespace != null ? var.istio_system_namespace : "istio-system"
-  istio_trust_domain              = var.istio_trust_domain != null ? var.istio_trust_domain : "cluster.local"
-  istio_values                    = var.istio_values != null ? var.istio_values : []
+  create_istio_system_namespace             = var.create_istio_system_namespace != null ? var.create_istio_system_namespace : true
+  create_istio_operator_namespace           = var.create_istio_operator_namespace != null ? var.create_istio_operator_namespace : true
+  istio_chart_name                          = var.istio_chart_name != null ? var.istio_chart_name : "istio-operator"
+  istio_chart_repository                    = var.istio_chart_repository != null ? var.istio_chart_repository : "https://stevehipwell.github.io/helm-charts/"
+  istio_chart_version                       = var.istio_chart_version != null ? var.istio_chart_version : "2.4.0"
+  istio_cluster_name                        = var.istio_cluster_name != null ? var.istio_cluster_name : null
+  istio_ingress_gateway_service_annotations = var.istio_ingress_gateway_service_annotations != null ? var.istio_ingress_gateway_service_annotations : {}
+  istio_mesh_id                             = var.istio_mesh_id != null ? var.istio_mesh_id : null
+  istio_network                             = var.istio_network != null ? var.istio_network : "network1"
+  istio_operator_namespace                  = var.istio_operator_namespace != null ? var.istio_operator_namespace : "istio-operator"
+  istio_profile                             = var.istio_profile != null ? var.istio_profile : "default"
+  istio_release_name                        = var.istio_release_name != null ? var.istio_release_name : "istio-operator"
+  istio_revision_tag                        = var.istio_revision_tag != null ? var.istio_revision_tag : "default"
+  istio_settings                            = var.istio_settings != null ? var.istio_settings : {}
+  istio_system_namespace                    = var.istio_system_namespace != null ? var.istio_system_namespace : "istio-system"
+  istio_trust_domain                        = var.istio_trust_domain != null ? var.istio_trust_domain : "cluster.local"
+  istio_values                              = var.istio_values != null ? var.istio_values : []
 
   # Kiali Operator Settings
   create_kiali_cr                 = var.create_kiali_cr != null ? var.create_kiali_cr : true
@@ -98,13 +99,14 @@ resource "helm_release" "istio_operator" {
   version          = local.istio_chart_version
 
   values = coalescelist(local.istio_values, [templatefile("${path.module}/values.yaml.tpl", {
-    cluster_name           = local.istio_cluster_name
-    mesh_id                = local.istio_mesh_id
-    network                = local.istio_network
-    revision_tag           = local.istio_revision_tag
-    istio_system_namespace = local.create_istio_system_namespace ? kubernetes_namespace.istio_system[0].metadata[0].name : local.istio_system_namespace
-    profile                = local.istio_profile
-    trust_domain           = local.istio_trust_domain
+    cluster_name                        = local.istio_cluster_name
+    mesh_id                             = local.istio_mesh_id
+    network                             = local.istio_network
+    revision_tag                        = local.istio_revision_tag
+    istio_system_namespace              = local.create_istio_system_namespace ? kubernetes_namespace.istio_system[0].metadata[0].name : local.istio_system_namespace
+    profile                             = local.istio_profile
+    trust_domain                        = local.istio_trust_domain
+    ingress_gateway_service_annotations = local.istio_ingress_gateway_service_annotations
     })]
   )
 

--- a/modules/istio-operator/values.yaml.tpl
+++ b/modules/istio-operator/values.yaml.tpl
@@ -33,10 +33,14 @@ controlPlane:
       ingressGateways:
         - name: istio-ingressgateway
           namespace: ${istio_system_namespace} 
-          enabled: true
+          enabled: true 
           label:
             cloud.streamnative.io/role: "istio-ingressgateway"
           k8s:
+            serviceAnnotations:
+%{ for k, v in ingress_gateway_service_annotations ~}
+              ${k}: "${v}"
+%{ endfor ~}
             service:
               ports:
                 - port: 15021

--- a/modules/istio-operator/variables.tf
+++ b/modules/istio-operator/variables.tf
@@ -78,6 +78,12 @@ variable "istio_cluster_name" {
   type        = string
 }
 
+variable "istio_ingress_gateway_service_annotations" {
+  default     = null
+  description = "Kubernetes annotations to add to the Istio IngressGateway Service."
+  type        = map(string)
+}
+
 variable "istio_mesh_id" {
   default     = null
   description = "The ID used by the Istio mesh. This is also the ID of the StreamNative Cloud Pool used for the workload environment."

--- a/modules/prometheus-operator/main.tf
+++ b/modules/prometheus-operator/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "prometheus_operator" {
   values           = local.values
 
   set {
-    name = "prometheusOperator.podAnnotations.traffic\\.sidecar\\.istio\\.io/excludeInboundPorts"
+    name  = "prometheusOperator.podAnnotations.traffic\\.sidecar\\.istio\\.io/excludeInboundPorts"
     value = "10250"
     type  = "string"
   }


### PR DESCRIPTION
On AWS, we'd like to be able to configure whether we have an internet-facing NLB or an internal NLB.

We've added an option to this base chart to accept annotations for the istio service.

Used by https://github.com/streamnative/terraform-aws-cloud/pull/71