### PR TITLE
Disable prometheus operator by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "enable_otel_collector" {
 
 variable "enable_prometheus_operator" {
   default     = false
-  description = "Enables the Prometheus Operator and other components via kube-stack-prometheus. Set to \"true\" by default."
+  description = "Enables the Prometheus Operator and other components via kube-stack-prometheus. Set to \"false\" by default. Prefer UO or customer's own o11y service."
   type        = bool
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "enable_otel_collector" {
 }
 
 variable "enable_prometheus_operator" {
-  default     = true
+  default     = false
   description = "Enables the Prometheus Operator and other components via kube-stack-prometheus. Set to \"true\" by default."
   type        = bool
 }


### PR DESCRIPTION
As UO becomes usable, we can disable local Prometheus stack by default for new pool members, to save efforts on continuing to support them, and put efforts on long term approaches: 1) enable log/metric collecting into their o11y vendors 2) or build services in control plane to expose log/metric from UO to customer