### PR TITLE
Set hpaSpec.minReplicas to 2 for istiod and istio-ingressgateway

### DIFF
--- a/modules/istio-operator/values.yaml.tpl
+++ b/modules/istio-operator/values.yaml.tpl
@@ -34,6 +34,8 @@ controlPlane:
         k8s:
           podDisruptionBudget:
             maxUnavailable: 1
+          hpaSpec:
+            minReplicas: 2
       ingressGateways:
         - name: istio-ingressgateway
           namespace: ${istio_system_namespace} 
@@ -43,6 +45,8 @@ controlPlane:
           k8s:
             podDisruptionBudget:
               maxUnavailable: 1
+            hpaSpec:
+              minReplicas: 2
             serviceAnnotations:
 %{ for k, v in ingress_gateway_service_annotations ~}
               ${k}: "${v}"


### PR DESCRIPTION
To avoid downtime when single istiod or istio-ingressgateway pod is evicted/rescheduled

