### PR TITLE
disable some component for kube-prometheus-stack

### DIFF
--- a/modules/prometheus-operator/main.tf
+++ b/modules/prometheus-operator/main.tf
@@ -41,10 +41,6 @@ locals {
   settings             = var.settings != null ? var.settings : {}
   timeout              = var.timeout != null ? var.timeout : 120
   values               = var.values != null ? var.values : []
-  alertmanager_enabled = var.alertmanager_enabled != null ? var.alertmanager_enabled : false
-  grafana_enabled      = var.grafana_enabled != null ? var.grafana_enabled : false
-  node_exporter_enabled = var.node_exporter_enabled != null ? var.node_exporter_enabled : false
-  kube_state_metrics_enabled = var.kube_state_metrics_enabled != null ? var.kube_state_metrics_enabled : false
 }
 
 resource "helm_release" "prometheus_operator" {
@@ -67,24 +63,19 @@ resource "helm_release" "prometheus_operator" {
 
   set {
     name  = "alertmanager.enabled"
-    value = local.alertmanager_enabled
-    type  = "auto"
-  }
-  set {
-    name  = "grafana.enabled"
-    value = local.grafana_enabled
+    value = "false"
     type  = "auto"
   }
 
   set {
     name  = "nodeExporter.enabled"
-    value = local.node_exporter_enabled
+    value = "false"
     type  = "auto"
   }
 
   set {
     name  = "kubeStateMetrics.enabled"
-    value = local.kube_state_metrics_enabled
+    value = "false"
     type  = "auto"
   }
 

--- a/modules/prometheus-operator/main.tf
+++ b/modules/prometheus-operator/main.tf
@@ -41,6 +41,10 @@ locals {
   settings             = var.settings != null ? var.settings : {}
   timeout              = var.timeout != null ? var.timeout : 120
   values               = var.values != null ? var.values : []
+  alertmanager_enabled = var.alertmanager_enabled != null ? var.alertmanager_enabled : false
+  grafana_enabled      = var.grafana_enabled != null ? var.grafana_enabled : false
+  node_exporter_enabled = var.node_exporter_enabled != null ? var.node_exporter_enabled : false
+  kube_state_metrics_enabled = var.kube_state_metrics_enabled != null ? var.kube_state_metrics_enabled : false
 }
 
 resource "helm_release" "prometheus_operator" {
@@ -59,6 +63,29 @@ resource "helm_release" "prometheus_operator" {
     name  = "prometheusOperator.podAnnotations.traffic\\.sidecar\\.istio\\.io/excludeInboundPorts"
     value = "10250"
     type  = "string"
+  }
+
+  set {
+    name  = "alertmanager.enabled"
+    value = local.alertmanager_enabled
+    type  = "auto"
+  }
+  set {
+    name  = "grafana.enabled"
+    value = local.grafana_enabled
+    type  = "auto"
+  }
+
+  set {
+    name  = "nodeExporter.enabled"
+    value = local.node_exporter_enabled
+    type  = "auto"
+  }
+
+  set {
+    name  = "kubeStateMetrics.enabled"
+    value = local.kube_state_metrics_enabled
+    type  = "auto"
   }
 
   dynamic "set" {

--- a/modules/prometheus-operator/variables.tf
+++ b/modules/prometheus-operator/variables.tf
@@ -78,30 +78,6 @@ variable "release_name" {
   type        = string
 }
 
-variable "alertmanager_enabled" {
-  default     = null
-  description = "Installs alertmanager or not."
-  type        = bool
-}
-
-variable "grafana_enabled" {
-  default     = null
-  description = "Installs grafana or not."
-  type        = bool
-}
-
-variable "node_exporter_enabled" {
-  default     = null
-  description = "Installs node-exporter or not."
-  type        = bool
-}
-
-variable "kube_state_metrics_enabled" {
-  default     = null
-  description = "Installs kube-state-metrics or not."
-  type        = bool
-}
-
 variable "settings" {
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values."

--- a/modules/prometheus-operator/variables.tf
+++ b/modules/prometheus-operator/variables.tf
@@ -78,6 +78,30 @@ variable "release_name" {
   type        = string
 }
 
+variable "alertmanager_enabled" {
+  default     = null
+  description = "Installs alertmanager or not."
+  type        = bool
+}
+
+variable "grafana_enabled" {
+  default     = null
+  description = "Installs grafana or not."
+  type        = bool
+}
+
+variable "node_exporter_enabled" {
+  default     = null
+  description = "Installs node-exporter or not."
+  type        = bool
+}
+
+variable "kube_state_metrics_enabled" {
+  default     = null
+  description = "Installs kube-state-metrics or not."
+  type        = bool
+}
+
 variable "settings" {
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values."


### PR DESCRIPTION
# Motivation 
The terraform module `prometheus-operator` uses  the opensource helm charts and will install alertmanager, grafana, nodeExporter, kubeStateMetrics by default, which is not expected. We should let the customer decide if install them or not.