### PR TITLE
fix: set versions range rather than exact

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.2.0"
+      version = "~> 2.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">=2.6.1"
+      version = "~> 2.8"
     }
   }
 }


### PR DESCRIPTION
### Motivation
As a root module, we should set a versions range rather than exact version, as it will block module consumer to upgrade.

Refer to this [best practice of version constraints](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#best-practices).