### PR TITLE
Fix OLM subscription for function mesh operator

### DIFF
--- a/modules/olm-subscriptions/chart/templates/functionmesh.yaml
+++ b/modules/olm-subscriptions/chart/templates/functionmesh.yaml
@@ -23,15 +23,15 @@ metadata:
 spec:
   channel: {{ .Values.functionMesh.channel | default .Values.channel }}
   config:
+    {{- if .Values.tolerations }}
+    tolerations:
+{{ toYaml .Values.tolerations | indent 4 }}
+    {{- end }}
     env:
     - name: ENABLE_WEBHOOKS
       value: "{{ .Values.functionMesh.config.enableWebhooks }}"
     - name: ENABLE_FUNCTION_MESH_CONTROLLER
       value: "{{ .Values.functionMesh.config.enableController }}"
-    {{- if .Values.tolerations }}
-    tolerations:
-{{ toYaml .Values.tolerations | indent 4 }}
-    {{- end }}
     {{- if .Values.functionMesh.config.env }}
     {{- toYaml .Values.functionMesh.config.env | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
The tolerations block was added to the wrong place, inadvertently intermixed with the `env` block.