### PR TITLE
feat: Support specify commonName in mesh cert

### DIFF
--- a/modules/istio-operator/charts/mesh/templates/certificate.yaml
+++ b/modules/istio-operator/charts/mesh/templates/certificate.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "mesh.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.ingressGateway.tlsCertificate.commonName }}
+  commonName: {{ .Values.ingressGateway.tlsCertificate.commonName }}
+  {{- end }}
   dnsNames: {{ toYaml .Values.ingressGateway.tlsCertificate.dnsNames | nindent 4 }}
   issuerRef:
     {{- toYaml .Values.ingressGateway.tlsCertificate.issuerRef | nindent 4 }}

--- a/modules/istio-operator/main.tf
+++ b/modules/istio-operator/main.tf
@@ -54,6 +54,7 @@ locals {
   istio_system_namespace                    = var.istio_system_namespace != null ? var.istio_system_namespace : "istio-system"
   istio_trust_domain                        = var.istio_trust_domain != null ? var.istio_trust_domain : "cluster.local"
   istio_values                              = var.istio_values != null ? var.istio_values : []
+  mesh_settings                             = var.mesh_settings != null ? var.mesh_settings : {}
 
   # Kiali Operator Settings
   create_kiali_cr                 = var.create_kiali_cr != null ? var.create_kiali_cr : true
@@ -144,6 +145,13 @@ resource "helm_release" "mesh" {
   cleanup_on_fail = local.cleanup_on_fail
   timeout         = local.timeout
   values          = [local.mesh_values]
+  dynamic "set" {
+    for_each = local.mesh_settings
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 
   depends_on = [
     time_sleep.wait_30_seconds

--- a/modules/istio-operator/variables.tf
+++ b/modules/istio-operator/variables.tf
@@ -162,6 +162,12 @@ variable "istio_values" {
   description = "A list of values in raw YAML to be applied to the helm release. Merges with the settings input, can also be used with the `file()` function, i.e. `file(\"my/values.yaml\")`."
 }
 
+variable "mesh_settings" {
+  default     = null
+  description = "Additional settings which will be passed to the mesh Helm chart."
+  type        = map(any)
+}
+
 ### Kiali Settings
 
 variable "create_kiali_cr" {


### PR DESCRIPTION
In some cases, we need to specify the `commonName` in cert to unblock some limits.
https://support.cpanel.net/hc/en-us/articles/4405807056023-Let-s-Encrypt-NewOrder-request-did-not-include-a-SAN-short-enough-to-fit-in-CN-